### PR TITLE
Fix results metadata and docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,7 @@ Kaplan’s efficient-frontier fit (Figure 1): L(C) = (<span style="white-space:n
 
 ---
 
-## 6 Reproduce / extend
+## 5 Reproduce / extend
 
 1. `git clone https://github.com/davidmoser/scaling_laws.git && cd scaling_laws`
 2. `pip install -r requirements.txt`

--- a/results/gpt2_112_results.json
+++ b/results/gpt2_112_results.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "model_name": "gpt2 112",
+    "model_name": "gpt2_112",
     "n_layers": 12,
     "d_model": 112,
     "n_heads": 8,

--- a/results/gpt2_128_results.json
+++ b/results/gpt2_128_results.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "model_name": "gpt2 128",
+    "model_name": "gpt2_128",
     "n_layers": 12,
     "d_model": 128,
     "n_heads": 8,

--- a/results/gpt2_160_results.json
+++ b/results/gpt2_160_results.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "model_name": "gpt2 160",
+    "model_name": "gpt2_160",
     "n_layers": 12,
     "d_model": 160,
     "n_heads": 8,

--- a/results/gpt2_196_results.json
+++ b/results/gpt2_196_results.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "model_name": "gpt2 196",
+    "model_name": "gpt2_196",
     "n_layers": 12,
     "d_model": 196,
     "n_heads": 8,

--- a/results/gpt2_256_results.json
+++ b/results/gpt2_256_results.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "model_name": "gpt2 256",
+    "model_name": "gpt2_256",
     "n_layers": 12,
     "d_model": 256,
     "n_heads": 8,

--- a/results/gpt2_32_results.json
+++ b/results/gpt2_32_results.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "model_name": "gpt2 32",
+    "model_name": "gpt2_32",
     "n_layers": 12,
     "d_model": 32,
     "n_heads": 8,

--- a/results/gpt2_48_results.json
+++ b/results/gpt2_48_results.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "model_name": "gpt2 48",
+    "model_name": "gpt2_48",
     "n_layers": 12,
     "d_model": 48,
     "n_heads": 8,

--- a/results/gpt2_64_results.json
+++ b/results/gpt2_64_results.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "model_name": "gpt2 64",
+    "model_name": "gpt2_64",
     "n_layers": 12,
     "d_model": 64,
     "n_heads": 8,

--- a/results/gpt2_64_results_long.json
+++ b/results/gpt2_64_results_long.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "model_name": "gpt2 64",
+    "model_name": "gpt2_64",
     "n_layers": 12,
     "d_model": 64,
     "n_heads": 8,

--- a/results/gpt2_96_results.json
+++ b/results/gpt2_96_results.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "model_name": "gpt2 96",
+    "model_name": "gpt2_96",
     "n_layers": 12,
     "d_model": 96,
     "n_heads": 8,

--- a/src/parse_from_log.py
+++ b/src/parse_from_log.py
@@ -628,7 +628,7 @@ import json
 import re
 import sys
 
-pattern = re.compile(r"^\s*(\d+)\s+([\d.]+)\s+([\d.]+)")  # step, train-loss, val-loss
+pattern = re.compile(r"^\s*(\d+)\s+([\d.]+)\s+([\d.]+)")  # step, train-loss, eval-loss
 
 data = {
     "train_loss": [],


### PR DESCRIPTION
## Summary
- normalize `model_name` field in saved JSON results
- correct comment describing `eval_loss` in log parser
- fix README section numbering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684011b641f48325956fdd85601a41af